### PR TITLE
Rephrase explanation of printf arguments

### DIFF
--- a/typo3/sysext/fluid/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/typo3/sysext/fluid/Classes/ViewHelpers/TranslateViewHelper.php
@@ -68,7 +68,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *    {f:translate(key: 'argumentsKey', arguments: {0: 'dog', 1: 'fox'}, default: 'default value')}
  *
  * Value of key ``argumentsKey`` in the current website language
- * with ``%1`` and ``%2`` are replaced by "dog" and "fox" (:php:`printf()`).
+ * with each declared as ``%s`` in the language file are replaced by "dog" and "fox" (:php:`printf()`).
  * If the key is not found, the output is "default value".
  *
  * Inline notation with extension name


### PR DESCRIPTION
The current documentation creates the impression that you can use `%1` (literally) in a language source file.
This PR changes the specifiers to `%s` while keeping the reference to the PHP `printf()` function.